### PR TITLE
add Dockerfile and docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+AUTH_TOKEN=LONG_LIVED_ACCESS_TOKEN
+HM_SERVICE_URI=http://home.domain.tld/api/services/notify/notify
+LISTEN_PORT=12000
+LISTEN_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 AUTH_TOKEN=LONG_LIVED_ACCESS_TOKEN
 HM_SERVICE_URI=http://home.domain.tld/api/services/notify/notify
 LISTEN_PORT=12000
-LISTEN_HOST=localhost
+LISTEN_HOST=0.0.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ cscope.po.out
 
 
 home-assistant-grafana-relay
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.19
+
+WORKDIR /usr/app
+
+COPY go.mod .
+RUN go mod download && go mod verify
+
+COPY main.go .
+RUN go build -v -o /usr/local/bin/app ./...
+
+CMD ["app"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ export LISTEN_HOST="localhost"
 ./home-assistant-grafana-relay
 ```
 
+### Run with docker-compose
+
+To build and run the service with docker, you can use the `Dockerfile`.
+In production you can use docker-compose to start the service automatically:
+
+1. clone this repository
+2. create `.env` from `.env.example`
+3. `cd home-assistant-grafana-relay`
+4. `docker-compose up -d`
+
 ## NixOS module
 
 A flake.nix file is included for compatibility with [Nix

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  grafana_relay:
+    container_name: grafana_relay
+    build: .
+    restart: always
+    env_file: .env
+    ports: 
+      - ${LISTEN_PORT}:${LISTEN_PORT}


### PR DESCRIPTION
Hey there,

thanks for this little app - it is exactly what I was looking for to hook grafana alerts into home assistant. I manage all the services on my pi for home-assistant with docker-compose and as I did not have go installed on my pi I just wrote a little Dockerfile for this. If you find it useful, I am happy to contribute this. Just tested it in my setup and it works :-)

Thanks again